### PR TITLE
Restore gitignore and lock file filtering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,6 +88,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bd389a4b2970a01282ee455294913c0a43724daedcd1a24c3eb0ec1c1320b66"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "doc-comment",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,6 +128,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0"
 dependencies = [
  "memchr",
+ "regex-automata",
  "serde",
 ]
 
@@ -233,6 +250,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
 name = "errno"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,6 +276,12 @@ name = "error-code"
 version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5d9305ccc6942a704f4335694ecd3de2ea531b114ac2d51f5f843750787a92f"
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fdeflate"
@@ -268,6 +303,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "gethostname"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -275,6 +319,18 @@ checksum = "0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818"
 dependencies = [
  "libc",
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi",
 ]
 
 [[package]]
@@ -368,6 +424,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,6 +460,12 @@ dependencies = [
  "adler2",
  "simd-adler32",
 ]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "num-traits"
@@ -528,6 +596,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,12 +644,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
 dependencies = [
  "bitflags 2.9.0",
+]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -580,7 +696,20 @@ dependencies = [
  "bitflags 2.9.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
+ "windows-sys",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+dependencies = [
+ "bitflags 2.9.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
  "windows-sys",
 ]
 
@@ -667,6 +796,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix 1.0.8",
+ "windows-sys",
+]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "tiff"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -690,6 +838,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -697,6 +854,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
 ]
 
 [[package]]
@@ -845,13 +1011,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.9.0",
+]
+
+[[package]]
 name = "x11rb"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d91ffca73ee7f68ce055750bf9f6eca0780b8c85eff9bc046a3b0da41755e12"
 dependencies = [
  "gethostname",
- "rustix",
+ "rustix 0.38.44",
  "x11rb-protocol",
 ]
 
@@ -866,11 +1041,14 @@ name = "xcat"
 version = "0.1.0"
 dependencies = [
  "arboard",
+ "assert_cmd",
  "clap",
  "colored",
  "glob",
  "globset",
  "ignore",
+ "predicates",
  "serde",
  "serde_json",
+ "tempfile",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,8 @@ ignore = "0.4"
 arboard = "3.3"
 glob = "0.3"
 globset = "0.4.16"
+
+[dev-dependencies]
+assert_cmd = "2"
+predicates = "3"
+tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A CLI utility that combines file viewing, directory traversal, and clipboard ope
 - **Flexible Options**: Control depth, filtering, and output format
 - **Clipboard Integration**: Automatically copies output to your clipboard
 - **JSON Export**: Option to export the structure as JSON
+- **Smart Ignoring**: Respects `.gitignore` files and skips common lock files unless `--include-locks` is specified
 
 ## Installation
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@
 use clap::Parser;
 use colored::*;
 use globset::{Glob, GlobMatcher};
-use ignore::{DirEntry, WalkBuilder};
+use ignore::{DirEntry, Walk, WalkBuilder};
 use serde::Serialize;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -55,6 +55,29 @@ struct TreeNode {
     is_dir: bool,
     is_empty: bool,
     children: Option<Vec<TreeNode>>,
+}
+
+const LOCK_FILE_NAMES: &[&str] = &[
+    "Cargo.lock",
+    "package-lock.json",
+    "yarn.lock",
+    "pnpm-lock.yaml",
+    "uv.lock",
+];
+
+fn build_walker(path: &Path, max_depth: Option<usize>) -> Walk {
+    let mut builder = WalkBuilder::new(path);
+    builder
+        .hidden(false)
+        .ignore(true)
+        .git_ignore(true)
+        .git_global(true)
+        .git_exclude(true)
+        .parents(true);
+    if let Some(depth) = max_depth {
+        builder.max_depth(Some(depth));
+    }
+    builder.build()
 }
 
 fn main() {
@@ -191,11 +214,7 @@ fn process_directory(
 }
 
 fn is_directory_empty(path: &Path, args: &Args, include_matcher: &Option<GlobMatcher>) -> bool {
-    let walker = WalkBuilder::new(path)
-        .max_depth(Some(1))
-        .hidden(false)
-        .standard_filters(true)
-        .build();
+    let walker = build_walker(path, Some(1));
 
     !walker.filter_map(Result::ok).any(|entry| {
         filter_entry(
@@ -223,11 +242,7 @@ fn collect_tree_output(
         }
     }
 
-    let walker = WalkBuilder::new(path)
-        .max_depth(Some(1))
-        .hidden(false)
-        .standard_filters(true)
-        .build();
+    let walker = build_walker(path, Some(1));
 
     let mut entries: Vec<_> = walker
         .filter_map(Result::ok)
@@ -327,14 +342,10 @@ fn build_json_tree(
         .into_owned();
     let is_dir = path.is_dir();
     // This is simplified, a more complex check might be needed depending on desired JSON output for empty/filtered dirs
-    let is_empty = is_dir && WalkBuilder::new(path).max_depth(Some(1)).build().count() <= 1;
+    let is_empty = is_dir && build_walker(path, Some(1)).count() <= 1;
 
     let children = if is_dir && max_depth.map_or(true, |max| depth < max) {
-        let walker = WalkBuilder::new(path)
-            .max_depth(Some(1))
-            .hidden(false)
-            .standard_filters(true)
-            .build();
+        let walker = build_walker(path, Some(1));
         let children_nodes: Vec<_> = walker
             .filter_map(Result::ok)
             .filter(|e| filter_entry(e, path, dirs_only, include_locks, include_matcher))
@@ -378,10 +389,7 @@ fn filter_entry(
     if let Some(matcher) = include_matcher {
         if path.is_dir() {
             // A directory is included if it recursively contains any file that matches the pattern.
-            let walker = WalkBuilder::new(path)
-                .hidden(false)
-                .standard_filters(true)
-                .build();
+            let walker = build_walker(path, None);
             return walker
                 .filter_map(Result::ok)
                 .any(|e| e.path().is_file() && matcher.is_match(e.path()));
@@ -394,8 +402,12 @@ fn filter_entry(
     if dirs_only && !path.is_dir() {
         return false;
     }
-    if !include_locks && path.file_name().map_or(false, |n| n == "Cargo.lock") {
-        return false;
+    if !include_locks {
+        if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+            if LOCK_FILE_NAMES.contains(&name) || name.ends_with(".lock") {
+                return false;
+            }
+        }
     }
     true
 }

--- a/tests/filters.rs
+++ b/tests/filters.rs
@@ -1,0 +1,62 @@
+use assert_cmd::Command;
+use serde_json::Value;
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn honors_gitignore() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = tempdir()?;
+    fs::write(dir.path().join(".gitignore"), "ignored.txt\n")?;
+    fs::write(dir.path().join("ignored.txt"), "ignored")?;
+    fs::write(dir.path().join("visible.txt"), "visible")?;
+    std::process::Command::new("git").arg("init").current_dir(dir.path()).output()?;
+
+    let assert = Command::cargo_bin("xcat")?
+        .current_dir(dir.path())
+        .arg("--no-copy")
+        .arg("--output")
+        .arg("json")
+        .assert()
+        .success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone())?;
+    let json: Value = serde_json::from_str(&stdout)?;
+    let children = json["children"].as_array().unwrap();
+    assert!(children.iter().any(|c| c["name"] == "visible.txt"));
+    assert!(!children.iter().any(|c| c["name"] == "ignored.txt"));
+    Ok(())
+}
+
+#[test]
+fn excludes_lock_files_by_default() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = tempdir()?;
+    fs::write(dir.path().join("uv.lock"), "")?;
+    fs::write(dir.path().join("visible.txt"), "visible")?;
+    std::process::Command::new("git").arg("init").current_dir(dir.path()).output()?;
+
+    let assert = Command::cargo_bin("xcat")?
+        .current_dir(dir.path())
+        .arg("--no-copy")
+        .arg("--output")
+        .arg("json")
+        .assert()
+        .success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone())?;
+    let json: Value = serde_json::from_str(&stdout)?;
+    let children = json["children"].as_array().unwrap();
+    assert!(children.iter().any(|c| c["name"] == "visible.txt"));
+    assert!(!children.iter().any(|c| c["name"] == "uv.lock"));
+
+    let assert = Command::cargo_bin("xcat")?
+        .current_dir(dir.path())
+        .arg("--no-copy")
+        .arg("--output")
+        .arg("json")
+        .arg("--include-locks")
+        .assert()
+        .success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone())?;
+    let json: Value = serde_json::from_str(&stdout)?;
+    let children = json["children"].as_array().unwrap();
+    assert!(children.iter().any(|c| c["name"] == "uv.lock"));
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Include `uv.lock` in default lock file ignore list
- Add regression tests verifying `.gitignore` is respected and lock files are excluded unless `--include-locks`

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a1ac368e8c8329a2eefd0b3285a3e5